### PR TITLE
změnění jména článku na xbox

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -141,7 +141,7 @@
 				</a>
 			</li>
 			<li class="size-half">
-				<a href="Playstation a X-Box" class="inner">
+				<a href="{{ site.baseurl }}/xbox" class="inner">
 					<p class="img">
 				<img src="{{ site.baseurl }}/images/xboxplaystation.jpg" alt="">
 					</p>


### PR DESCRIPTION
Přejmenování <a href="{{ site.baseurl }}/Playstation a X-Box" class="inner"> na <a href="{{ site.baseurl }}/xbox" class="inner">
